### PR TITLE
0 day contracts result in ZeroDivisionError

### DIFF
--- a/tda_options.py
+++ b/tda_options.py
@@ -72,7 +72,8 @@ def get_put_info(ticker_list, investment, ignore_in_the_money=True, verbose=True
                         # ask = contract["ask"]
                         num_contracts = int(investment / (strike * 100))
                         premium = num_contracts * bid * 100
-                        income_per_day = round(premium / days, 2)
+                        income_per_day = \
+                            round((premium / days) if days > 0 else premium, 2)
                         in_the_money = contract["inTheMoney"]
                         if ignore_in_the_money and in_the_money:
                             continue


### PR DESCRIPTION
Thanks for sharing this on reddit! Running it today with the example args, the daily income calculation is dividing by 0:

```
python download.py riot,lvs,gold 10000 list.csv
Processing RIOT (1/3)
Traceback (most recent call last):
  File "download.py", line 38, in <module>
    main()
  File "download.py", line 28, in main
    put_info_text, put_info_df = get_put_info(ticker_list, investment, verbose=verbose)
  File "options_analysis_service\tda_options.py", line 75, in get_put_info
    income_per_day = round(premium / days, 2)
ZeroDivisionError: float division by zero
```

Once I added a condition for 0 days, the output is being generated successfully:

```
Processing RIOT (1/3)
Processing LVS (2/3)
Processing GOLD (3/3)
   Ticker  Expiration  Days  Strike  Premium  IncomePerDay  Num_Contracts   Bid  InTheMoney
6    RIOT  2020-08-21     0     3.5    140.0         140.0             28  0.05       False
23   GOLD  2020-08-21     0    29.0     99.0          99.0              3  0.33       False
20   RIOT  2020-09-04    14     3.5    980.0          70.0             28  0.35       False
13   RIOT  2020-08-28     7     3.5    420.0          60.0             28  0.15       False
13    LVS  2020-08-21     0    46.0     50.0          50.0              2  0.25       False
``` 
